### PR TITLE
include license in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Thank you for `robotframework-axelibrary `!

This PR adds the LICENSE file to source distributions.

My motivation for this is repackaging on `conda-forge`: it's not a blocker, as we can source the LICENSE from the tag, but it would be lovely for it to be in a tidy bundle.

Thanks again!